### PR TITLE
Fix OpenVidu::getRecording()

### DIFF
--- a/src/OpenVidu.php
+++ b/src/OpenVidu.php
@@ -188,7 +188,7 @@ class OpenVidu
      * @throws OpenViduRecordingNotFoundException
      * @throws Exceptions\OpenViduInvalidArgumentException
      */
-    public function getRecording(string $recordingId): string
+    public function getRecording(string $recordingId)
     {
         $response = $this->client()->get(Uri::RECORDINGS_URI.'/'.$recordingId);
         switch ($response->getStatusCode()) {


### PR DESCRIPTION
 If OpenVidu::getRecording() returns string, it serializes only id, but not other data

