### PR TITLE
Revert "Bugfixes in resolving session's last recording id"

### DIFF
--- a/src/Http/Controllers/OpenViduController.php
+++ b/src/Http/Controllers/OpenViduController.php
@@ -27,7 +27,7 @@ class OpenViduController extends Controller
      */
     public function token(GenerateTokenRequest $request)
     {
-        $session = OpenVidu::createSession(SessionPropertiesBuilder::build($request->get('session')), $request->get('force'));
+        $session = OpenVidu::createSession(SessionPropertiesBuilder::build($request->get('session')));
         $token = $session->generateToken(TokenOptionsBuilder::build($request->get('tokenOptions')));
         return Response::json(['token' => $token], 200);
     }

--- a/src/RecordingProperties.php
+++ b/src/RecordingProperties.php
@@ -66,7 +66,6 @@ class RecordingProperties implements JsonSerializable
         return $this->session;
     }
 
-
     /**
      * Defines the name you want to give to the video file. You can access this same
      * value in your clients on recording events (<code>recordingStarted</code>,

--- a/src/Session.php
+++ b/src/Session.php
@@ -98,7 +98,7 @@ class Session implements JsonSerializable
         $this->getSessionId();
         try {
             if (!$tokenOptions) {
-                $tokenOptions = new TokenOptions(OpenViduRole::PUBLISHER);
+                $tokenOptions = new TokenOptions(OpenViduRole::PUBLISHER);;
             }
             $response = $this->client->post(Uri::TOKEN_URI, [
                 RequestOptions::JSON => array_merge($tokenOptions->toArray(), ['session' => $this->sessionId])
@@ -197,7 +197,7 @@ class Session implements JsonSerializable
      */
     public function toArray(): array
     {
-        $array = ['sessionId' => $this->sessionId, 'properties' => $this->properties->toArray(), 'recording' => $this->recording, 'createdAt' => $this->createdAt, 'lastRecordingId'=>$this->lastRecordingId];
+        $array = ['sessionId' => $this->sessionId, 'properties' => $this->properties->toArray(), 'recording' => $this->recording, 'createdAt' => $this->createdAt];
         foreach ($this->activeConnections as $connection) {
             $array['activeConnections'][] = $connection->toArray();
         }
@@ -228,7 +228,6 @@ class Session implements JsonSerializable
         $this->sessionId = $sessionArray['sessionId'];
         $this->createdAt = $sessionArray['createdAt'] ?? null;
         $this->recording = $sessionArray['recording'] ?? null;
-        $this->lastRecordingId = $sessionArray['lastRecordingId'] ?? null;
 
         if (array_key_exists('properties', $sessionArray)) {
             $this->properties = SessionPropertiesBuilder::build($sessionArray['properties']);
@@ -399,7 +398,7 @@ class Session implements JsonSerializable
         return $this->lastRecordingId;        
     }
 
-    public function setLastRecordingId($lastRecordingId) {
+    public function setLastRecordingId(string $lastRecordingId) {
         $this->lastRecordingId = $lastRecordingId;
         Cache::store('openvidu')->update($this->sessionId, $this->toJson());
     }


### PR DESCRIPTION
Reverts squareetlabs/LaravelOpenVidu#9
On line 30 of OpenviduController the createSession method is called by passing two parameters but the method signature only supports one