### PR TITLE
2.15.0 openvidu version

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -242,8 +242,8 @@ class Session implements JsonSerializable
                     $publishers[] = PublisherBuilder::build($publisher);
                 }
                 $subscribers = [];
-                foreach ($ensure->subscribers as $subscriber) {
-                    $subscribers[] = $subscriber->streamId;
+                foreach ($ensure->subscribers as $subscriber) {                
+                    $subscribers[] = $subscriber['streamId'];
                 }
                 $this->activeConnections[] = ConnectionBuilder::build($ensure, $publishers, $subscribers);
             }


### PR DESCRIPTION
For solving this error:

![af01697af621_17-09-2020-01:47:22_af01](https://user-images.githubusercontent.com/1280194/93449224-2aef2d00-f8dd-11ea-80c9-cd9b5cae80cd.png)

I understand that this comes from newer version of openvidu

Probably should be mentioned which version master branch targets
